### PR TITLE
Move HTTPError handling to `search.get_valid_request`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,14 @@ the other features like list and table output, debug, etc.
 python -m pytest
 ```
 
+or, for authenticated requests:
+
+```bash
+python -m pytest --auth [username]:[token]
+```
+
+Where **username** = your GitHub username and **token** = a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). Authenticating your request will allow you to test authentication features and use a higher rate limit with the GitHub API. *This token does not need any permissions!*
+
 **Linting checks**
 
 ```bash

--- a/starcli/__main__.py
+++ b/starcli/__main__.py
@@ -1,9 +1,6 @@
 """ starcli.__main__ """
 
-from time import sleep
-
 import click
-from requests.exceptions import HTTPError
 import re
 
 from .layouts import list_layout, table_layout, grid_layout, shorten_count
@@ -129,35 +126,16 @@ def cli(
         )
         auth = None
 
-    while True:
-        try:
-            if (
-                not spoken_language and not date_range
-            ):  # if filtering by spoken language and date range not required
-                tmp_repos = search(
-                    lang, created, pushed, stars, topic, user, debug, order, auth
-                )
-            else:
-                tmp_repos = search_github_trending(
-                    lang, spoken_language, order, stars, date_range
-                )
-            break  # Need this here to break out of the loop if the request is successful
-        except HTTPError as e:  # If a request is unsuccessful
-            status_code = str(e).split(" ")[3]
-            handling_code = search_error(status_code)
-            if handling_code == "retry":
-                for i in range(15, 0, -1):
-                    click.secho(
-                        f"{status_actions[handling_code]} {i} seconds...",
-                        fg="bright_yellow",
-                    )  # Print and update a timer
-                    sleep(1)
-            elif handling_code in status_actions:
-                click.secho(status_actions[handling_code], fg="bright_yellow")
-                return
-            else:
-                click.secho("An invalid handling code was returned.", fg="bright_red")
-                return
+    if (
+        not spoken_language and not date_range
+    ):  # if filtering by spoken language and date range not required
+        tmp_repos = search(
+            lang, created, pushed, stars, topic, user, debug, order, auth
+        )
+    else:
+        tmp_repos = search_github_trending(
+            lang, spoken_language, order, stars, date_range
+        )
 
     if not tmp_repos:  # if search() returned None
         return

--- a/starcli/search.py
+++ b/starcli/search.py
@@ -2,6 +2,7 @@
 
 # Standard library imports
 from datetime import datetime, timedelta
+from time import sleep
 import logging
 from random import randint
 import re
@@ -79,17 +80,34 @@ def get_valid_request(url, auth=""):
     """
     Provide a URL to submit a GET request for and handle a connection error or raise an assertion error if an HTTP status code indicating anything other than a success was received.
     """
-    try:
-        session = requests.Session()
-        if auth:
-            session.auth = (auth.split(":")[0], auth.split(":")[1])
-        request = session.get(url)
-    except requests.exceptions.ConnectionError:
-        secho("Internet connection error...", fg="bright_red")
-        return None
+    while True:
+        try:
+            session = requests.Session()
+            if auth:
+                session.auth = (auth.split(":")[0], auth.split(":")[1])
+            request = session.get(url)
+        except requests.exceptions.ConnectionError:
+            secho("Internet connection error...", fg="bright_red")
+            return None
 
-    if not request.status_code in (200, 202):
-        raise requests.exceptions.HTTPError(f"HTTP Status Code: {request.status_code}")
+        if not request.status_code in (200, 202):
+            handling_code = search_error(request.status_code)
+            if handling_code == "retry":
+                for i in range(15, 0, -1):
+                    secho(
+                        f"{status_actions[handling_code]} {i} seconds...",
+                        fg="bright_yellow",
+                    )  # Print and update a timer
+                    sleep(1)
+            elif handling_code in status_actions:
+                secho(status_actions[handling_code], fg="bright_yellow")
+                return None
+            else:
+                secho("An invalid handling code was returned.", fg="bright_red")
+                return None
+        else:
+            break
+
     return request
 
 
@@ -183,8 +201,6 @@ def search(
         print("DEBUG: auth: off")
 
     request = get_valid_request(url, auth)
-    if request is None:
-        return request
 
     return request.json()["items"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--auth",
+        action="store",
+        default="",
+        help="username:token to pass to test functions",
+    )
+
+
+@pytest.fixture(scope="class")
+def auth(request):
+    request.cls.auth = request.config.getoption("--auth")
+    return request.config.getoption("--auth")
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "auth: mark test as requiring authentication token"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--auth"):
+        # --auth given in cli: do not skip auth-required tests
+        return
+    skip_auth = pytest.mark.skip(reason="need --auth option to run")
+    for item in items:
+        if "auth" in item.keywords:
+            item.add_marker(skip_auth)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,264 @@
+""" tests.test_cli """
+
+from click.testing import CliRunner
+import pytest
+from datetime import datetime, timedelta
+from random import randint
+from sys import maxsize
+import re
+
+from starcli.__main__ import cli
+
+
+@pytest.mark.usefixtures("auth")
+class TestCli:
+    def test_cli_debug(self):
+        """ Test cli when --debug is passed """
+        result = self.cli_result(debug=True)
+        self.assertions(result, debug=True)
+
+    def test_cli(self):
+        """ Test cli when no commands given & debug+auth off"""
+        result = self.cli_result(debug=False, auth="")
+        self.assertions(result, debug=False)
+
+    @pytest.mark.auth  # This test needs --auth, otherwise skip
+    def test_auth(self, auth):
+        """ Test basic authentication for valid auth credentials """
+        result = self.cli_result(auth=self.auth)
+        self.assertions(
+            result,
+            in_output=("DEBUG: auth: on"),
+            not_in_output="The server did not accept the credentials.",
+        )
+
+    def test_no_auth(self):
+        """ Test without --auth"""
+        result = self.cli_result(auth="")
+        self.assertions(result, in_output=("DEBUG: auth: off"))
+
+    def test_incorrect_auth(self):
+        """ Test incorrect credentials provided to --auth """
+        result = self.cli_result(auth="github:0000")
+        self.assertions(
+            result, in_output=("The server did not accept the credentials.")
+        )
+
+    def test_invalid_auth_format(self):
+        """ Test invalid credentials provided to --auth """
+        result = self.cli_result(auth="github:")
+        self.assertions(result, in_output=("Invalid authentication format:"))
+
+        result = self.cli_result(auth=":0000")
+        self.assertions(result, in_output=("Invalid authentication format:"))
+
+    def test_cli_lang(self):
+        """ Test cli when --lang or -l is passed """
+        param_decls = ["--lang", "-l"]
+
+        for param in param_decls:
+            result = self.cli_result(param, "python")
+            self.assertions(result, in_output=("language:python"))
+
+    def test_cli_spoken_language(self):
+        """ Test cli when --spoken-language or -S is passed """
+        param_decls = ["--spoken-language", "-S"]
+        # Currently, this option uses `search_github_trending`, which produces no 'DEBUG:'
+        for param in param_decls:
+            result = self.cli_result(param, "en")
+            self.assertions(result, debug=False)
+
+    def test_cli_created(self):
+        """ Test cli when --created or -c with valid option is passed """
+        param_decls = ["--created", "-c"]
+
+        for param in param_decls:
+            date_format = "%Y-%m-%d"
+            day_range = 0 - randint(100, 400)
+            created_date_value = ">=" + (
+                datetime.utcnow() + timedelta(days=day_range)
+            ).strftime(date_format)
+            result = self.cli_result(param, created_date_value)
+            self.assertions(result, not_in_output=("Invalid Date"))
+
+    def test_cli_created_invalid(self):
+        """ Test cli when --created or -c with invalid option is passed """
+        param_decls = ["--created", "-c"]
+
+        for param in param_decls:
+            date_format = "%d-%m-%Y"
+            day_range = 0 - randint(100, 400)
+            created_date_value = (
+                datetime.utcnow() + timedelta(days=day_range)
+            ).strftime(date_format)
+            result = self.cli_result(param, created_date_value)
+            self.assertions(
+                result,
+                in_output=(f"Invalid date: {created_date_value} must be yyyy-mm-dd"),
+            )
+
+    def test_cli_topic(self):
+        """ Test cli when --topic or -t is passed """
+        param_decls = ["--topic", "-t"]
+
+        for param in param_decls:
+            result = self.cli_result(
+                param, "javascript", param, "nodejs"
+            )  # javascript + nodejs will likely come up together
+            self.assertions(result)
+
+    def test_cli_pushed(self):
+        """ Test cli when --pushed or -p is passed """
+        param_decls = ["--pushed", "-p"]
+
+        for param in param_decls:
+            date_format = "%Y-%m-%d"
+            day_range = 0 - randint(100, 400)
+            pushed_date_value = (
+                datetime.utcnow() + timedelta(days=day_range)
+            ).strftime(date_format)
+            result = self.cli_result(param, pushed_date_value)
+            self.assertions(result, not_in_output=("Invalid date:"))
+
+    def test_cli_pushed_invalid(self):
+        """ Test cli when invalid option to --pushed or -p is passed """
+        param_decls = ["--pushed", "-p"]
+
+        for param in param_decls:
+            date_format = "%d-%m-%Y"
+            day_range = 0 - randint(100, 400)
+            pushed_date_value = (
+                datetime.utcnow() + timedelta(days=day_range)
+            ).strftime(date_format)
+            result = self.cli_result(param, pushed_date_value)
+            self.assertions(
+                result,
+                in_output=(f"Invalid date: {pushed_date_value} must be yyyy-mm-dd"),
+            )
+
+    def test_cli_layout(self):
+        """ Test cli when --layout or -L is passed """
+        param_decls = ["--layout", "-L"]
+        choices = ["list", "table", "grid"]
+
+        for param in param_decls:
+            for choice in choices:
+                result = self.cli_result(param, choice)
+                self.assertions(result)
+
+    def test_cli_stars(self):
+        """ Test cli when --stars or -s is passed """
+        param_decls = ["--stars", "-s"]
+
+        for param in param_decls:
+            result = self.cli_result(param, 0)
+            self.assertions(result)
+
+            result = self.cli_result(param, 1)
+            self.assertions(result)
+
+            result = self.cli_result(param, maxsize)
+            self.assertions(result)
+
+    def test_cli_limit_results(self):
+        """ Test cli when --limit-results or -r is passed """
+        param_decls = ["--limit-results", "-r"]
+
+        for param in param_decls:
+            result = self.cli_result(param, 0)
+            self.assertions(result)
+
+            result = self.cli_result(param, 1)
+            self.assertions(result)
+
+            result = self.cli_result(param, maxsize)
+            self.assertions(result)
+
+            result = self.cli_result(param, -1)
+            self.assertions(result)
+
+    def test_cli_order(self):
+        """ Test cli when --order or -o is passed """
+        param_decls = ["--order", "-o"]
+        choices = ["desc", "asc"]
+
+        for param in param_decls:
+            for choice in choices:
+                result = self.cli_result(param, choice)
+                self.assertions(result)
+
+    def test_cli_long_stats(self):
+        """ Test cli when --long-stats is passed """
+        result = self.cli_result("--long-stats")
+        self.assertions(result)
+
+    def test_cli_date_range(self):
+        """ Test cli when --date-range or -d is passed """
+        param_decls = ["--date-range", "-d"]
+        choices = ["today", "this-week", "this-month"]
+        # Currently, this option uses `search_github_trending`, which produces no 'DEBUG:'
+        for param in param_decls:
+            for choice in choices:
+                result = self.cli_result(param, choice)
+                self.assertions(result, debug=False)
+
+    def test_cli_user(self):
+        """ Test cli when --user or -U is passed """
+        param_decls = ["--user", "-u"]
+
+        for param in param_decls:
+            result = self.cli_result(param, "github")
+            self.assertions(result)
+
+    def cli_result(
+        self, *args, debug=True, auth="",
+    ):
+        """ 
+        CliRunner() helper function. Returns a `click.testing.Result` object.
+        Passes `--debug` by default. Passes `--auth` + credentials, if given.
+        """
+        runner = CliRunner()
+        cli_params = [param for param in args]
+
+        if auth:
+            cli_params.extend(["--auth", auth])
+        elif self.auth:
+            cli_params.extend(["--auth", self.auth])
+
+        if debug:
+            cli_params.append("--debug")
+
+        return runner.invoke(cli, cli_params) if cli_params else runner.invoke(cli)
+
+    def assertions(
+        self,
+        result,
+        exit_code=0,
+        output=True,
+        debug=True,
+        in_output=(),
+        not_in_output=(),
+    ):
+        """
+        Helper function for basic assert statements.
+        """
+        if exit_code:
+            assert result.exit_code == exit_code, f"`exit_code` should be '{exit_code}'"
+        if debug:
+            assert "DEBUG:" in result.output, f"'DEBUG' not in `result.output`"
+        if output:
+            assert result.output, "No cli output generated"
+        elif not output:
+            assert not result.output, "Cli output generated, but expected nothing"
+        if in_output:
+            for s in in_output:
+                assert (
+                    re.search(s, result.output),
+                    f"'{s}' not found in `result.output.`",
+                )
+        if not_in_output:
+            for s in not_in_output:
+                assert (
+                    False if re.search(s, result.output) else True,
+                    f"{not_in_output} found in `result.output`, but shouldn't be.",
+                )


### PR DESCRIPTION
<!--In contributing to this repository, you must follow our code of conduct.-->
<!--If it's just a typo fix, or a very small change, just describe it in 1-2 sentences
here and ignore everything below-->
<!--Remember that your code will be checked by the black formatter, pylint, codespell, and pytest.-->

Move HTTPError handling to `search.get_valid_request`

**Context**
<!--Is this pull request in context of any issues? If so link them here
Remember to use 'resolves #0', 'closes #0' or something like that if this pull
request can resolve an issue when merged.-->

Currently, `__main__` is handling an HTTPError and using that to execute the strategy to poll the API again. This is an issue because it means the behavior of `search` can't reliably return the same result when the result isn't 200/202 - unless we want to build exception handling and retry code inside of `test_search.py`, which doesn't seem DRY and could cause issues later if we need to change the `request.status_code` strategy.

**Description**

<!--Clearly describe the changes you made, include before/after screenshots IF NEEDED-->
This way, `get_valid_request` does something closer to what the function name suggests. It also means we don't need to import requests libraries into `__main__`.