### PR TITLE
Moves retry logic into search.get_valid_request

### DIFF
--- a/starcli/__main__.py
+++ b/starcli/__main__.py
@@ -1,9 +1,6 @@
 """ starcli.__main__ """
 
-from time import sleep
-
 import click
-from requests.exceptions import HTTPError
 import re
 
 from .layouts import list_layout, table_layout, grid_layout, shorten_count
@@ -129,35 +126,16 @@ def cli(
         )
         auth = None
 
-    while True:
-        try:
-            if (
-                not spoken_language and not date_range
-            ):  # if filtering by spoken language and date range not required
-                tmp_repos = search(
-                    lang, created, pushed, stars, topic, user, debug, order, auth
-                )
-            else:
-                tmp_repos = search_github_trending(
-                    lang, spoken_language, order, stars, date_range
-                )
-            break  # Need this here to break out of the loop if the request is successful
-        except HTTPError as e:  # If a request is unsuccessful
-            status_code = str(e).split(" ")[3]
-            handling_code = search_error(status_code)
-            if handling_code == "retry":
-                for i in range(15, 0, -1):
-                    click.secho(
-                        f"{status_actions[handling_code]} {i} seconds...",
-                        fg="bright_yellow",
-                    )  # Print and update a timer
-                    sleep(1)
-            elif handling_code in status_actions:
-                click.secho(status_actions[handling_code], fg="bright_yellow")
-                return
-            else:
-                click.secho("An invalid handling code was returned.", fg="bright_red")
-                return
+    if (
+        not spoken_language and not date_range
+    ):  # if filtering by spoken language and date range not required
+        tmp_repos = search(
+            lang, created, pushed, stars, topic, user, debug, order, auth
+        )
+    else:
+        tmp_repos = search_github_trending(
+            lang, spoken_language, order, stars, date_range
+        )
 
     if not tmp_repos:  # if search() returned None
         return


### PR DESCRIPTION
<!--In contributing to this repository, you must follow our code of conduct.-->
<!--If it's just a typo fix, or a very small change, just describe it in 1-2 sentences
here and ignore everything below-->
<!--Remember that your code will be checked by the black formatter, pylint, codespell, and pytest.-->

Move HTTPError handling to search.get_valid_request

**Context**
<!--Is this pull request in context of any issues? If so link them here
Remember to use 'resolves #0', 'closes #0' or something like that if this pull
request can resolve an issue when merged.-->

Currently, __main__ is handling an HTTPError and using that to execute the strategy to poll the API again. This is an issue because it means the behavior of search can't reliably return the same result when the result isn't 200/202 - unless we want to build exception handling and retry code inside of test_search.py, which doesn't seem DRY and could cause issues later if we need to change the request.status_code strategy.

**Description**
<!--Clearly describe the changes you made, include before/after screenshots IF NEEDED-->

This way, get_valid_request does something closer to what the function name suggests. It also means we don't need to import requests libraries into __main__.