### PR TITLE
Added support for caching results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,10 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# IDE specific
+.DS_Store
+.idea/
+
+# Cache file
+.cached_result.json


### PR DESCRIPTION
<!--If it's just a typo fix, or a very small change, just describe it in 1-2 sentences
here and ignore everything below-->

**Checklist**

- [X] My code is properly formatted using the latest [black](https://github.com/psf/black) <!--Don't worry if you don't know what this is, the formatting checks will still pass-->
- [ ] I have added/updated [tests](https://github.com/hedythedev/starcli/tree/main/tests) if needed <!--pytest-->
- [X] I have tried running my code manually <!-- run using `python3 -m starcli` -->
- [X] I have checked for spelling errors <!--The code will be run through codespell-->
<!--
  Please mark this PR as draft if it is still work in progress
  and feel free to add to this checklist if you like
-->


**Description**
Resolves #61
Added support to cache the responses to a JSON file which will get created when the user first runs the program and also added it to .gitignore so that it will not be tracked by git.

The cache file looks something like this after few requests
<img width="1688" alt="cached_results" src="https://user-images.githubusercontent.com/44431401/107855333-96670780-6e47-11eb-8562-e8148a44c37c.png">

Those are the keys, which contains the content of the responses.

<!--
- Clearly describe the changes you made
- include before/after screenshots IF NEEDED
- if this pull request can close an issue when merged, link to it here uisng 'resolves #0' or 'closes #0'
More info: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

